### PR TITLE
Changed on push to on push to main in ftp-deploy.yml

### DIFF
--- a/.github/workflows/ftp-deploy.yml
+++ b/.github/workflows/ftp-deploy.yml
@@ -1,10 +1,12 @@
-on: push
+on:
+  push:
+    branches:
+      - main
 name: Deploy website on push
 jobs:
   web-deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     steps:
     - name: Get latest code
       uses: actions/checkout@v3


### PR DESCRIPTION
Currently, the FTP Deploy action is triggered whenever any push is made. Then, if and only if the push was made to `main`, it will run the FTP Deploy action. If we continue to do it this way, then every time any push is made, it will trigger the action, and many will look like this:
![image](https://github.com/Mesure73L/mesure.x10.mx/assets/74377508/8fe42ef6-1731-4704-ab0b-e9fb3e774920)
We don't want that. I changed it to only triggering the action in the first place if the push was made to `main`. That way, there will be no more "skipped" actions like that.