### PR TITLE
Removed push trigger from Netlfy Deploy action

### DIFF
--- a/.github/workflows/netlify-twelve-of-code.yml
+++ b/.github/workflows/netlify-twelve-of-code.yml
@@ -1,7 +1,6 @@
 # .github/workflows/netlify.yml
 name: Build and Deploy to Netlify
 on:
-  push:
   pull_request:
     types: [labeled, edited, opened, reopened]
 jobs:

--- a/.github/workflows/netlify-twelve-of-code.yml
+++ b/.github/workflows/netlify-twelve-of-code.yml
@@ -14,6 +14,7 @@ jobs:
 
       - name: Deploy Twelve of Code to Netlify
         uses: nwtgck/actions-netlify@v2.0
+        permissions: read-all
         with:
           publish-dir: './'
           production-branch: main


### PR DESCRIPTION
Right now, the Netlify Deploy action will be run on a push or a pull request, but will only proceed to run if it has the twelve of code label, which is only possible on a pull request. This results in many "skipped" actions. So, I removed the pull trigger from the Netlify Deploy action.